### PR TITLE
fix: Fix Rules component return syntax

### DIFF
--- a/client/src/components/Rules.tsx
+++ b/client/src/components/Rules.tsx
@@ -1,32 +1,29 @@
-export const Rules = () => {
-  return;
-  <>
-    <section className="section">
-      <div>
-        <h1> Welcome to Pokémon Top Trumps! Gotta Catch ‘Em All!</h1>
-      </div>
-      <div>
-        <h2> Here are the rules to play. </h2>
-      </div>
-      <div> The game is out of 5 rounds.</div>
-      <div>Each player is given 5 random Pokémon cards. </div>
-      <div>
-        Each card has details about the Pokemon include 5 key stats that can be
-        compared. These stats are. Attack,Speed,Defence,Hit Point(hp),Weight
-      </div>
-      <div>
-        A player gets to turn their card first and pick an attribute to compare
-        against the other players.
-      </div>
+export const Rules = () => (
+  <section className="section">
+    <div>
+      <h1> Welcome to Pokémon Top Trumps! Gotta Catch ‘Em All!</h1>
+    </div>
+    <div>
+      <h2> Here are the rules to play. </h2>
+    </div>
+    <div> The game is out of 5 rounds.</div>
+    <div>Each player is given 5 random Pokémon cards. </div>
+    <div>
+      Each card has details about the Pokemon include 5 key stats that can be
+      compared. These stats are. Attack,Speed,Defence,Hit Point(hp),Weight
+    </div>
+    <div>
+      A player gets to turn their card first and pick an attribute to compare
+      against the other players.
+    </div>
 
-      <div>
-        The other players cards then flip over and the stat of the attribute
-        chosen by the player is compared.
-      </div>
-      <div>
-        The player with the higher stat for that attribute wins the round!
-      </div>
-      <div>The player with the most wins in 5 rounds is the winner!</div>
-    </section>
-  </>;
-};
+    <div>
+      The other players cards then flip over and the stat of the attribute
+      chosen by the player is compared.
+    </div>
+    <div>
+      The player with the higher stat for that attribute wins the round!
+    </div>
+    <div>The player with the most wins in 5 rounds is the winner!</div>
+  </section>
+);


### PR DESCRIPTION
Rules component return had an extra semicolon that made the return code unreachable. Updated the return to be implicit.