### PR TITLE
Player score component

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.6",
         "@testing-library/react": "^14.1.2",
+        "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -1532,6 +1533,19 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2398,6 +2412,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -2503,11 +2522,6 @@
       "engines": {
         "node": ">=0.8"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "classnames": "^2.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1633,6 +1634,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "classnames": "^2.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.6",
     "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^6.14.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,28 @@
 import "./App.css";
+import PlayerScore from "./components/PlayerScore/PlayerScore";
+import { DEFAULT_ROUNDS } from "./constants/constants";
 
 function App() {
   return (
     <>
-      <h1>This is our Client server running!!!</h1>
+      <PlayerScore
+        playerName={"Player 1"}
+        playerId={"player1"}
+        updateName={() => {}}
+        playerScore={0}
+        currentRound={1}
+        totalRounds={DEFAULT_ROUNDS}
+        roundWinners={[]}
+      />
+      <PlayerScore
+        playerName={"Player 2"}
+        playerId={"player2"}
+        updateName={() => {}}
+        playerScore={0}
+        currentRound={1}
+        totalRounds={DEFAULT_ROUNDS}
+        roundWinners={[]}
+      />
     </>
   );
 }

--- a/client/src/components/ErrorMessage/ErrorMessage.test.tsx
+++ b/client/src/components/ErrorMessage/ErrorMessage.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import ErrorMessage from "./ErrorMessage";
+
+test("Given the required props, When the component renders, Then an error should be present", () => {
+  const props = {
+    messages: ["here is an error"],
+  };
+  render(<ErrorMessage {...props} />);
+
+  const errorMessage = screen.getByText(props.messages[0]);
+
+  expect(errorMessage).toHaveClass("error");
+  expect(errorMessage).toBeInTheDocument();
+});
+
+test("Given the required props, When the component renders and there are no errorMessages, Then no error should be present", () => {
+  const props = {
+    messages: [],
+  };
+
+  const { container } = render(<ErrorMessage {...props} />);
+
+  expect(container.firstChild).not.toBeInTheDocument();
+});
+
+test("Given the required props, When the component renders, Then error should be present for each message", () => {
+  const props = {
+    messages: [
+      "here is an error",
+      "here is another error",
+      "what if there's a third error?!",
+    ],
+  };
+
+  render(<ErrorMessage {...props} />);
+
+  const errorMessage1 = screen.getByText(props.messages[0]);
+  const errorMessage2 = screen.getByText(props.messages[1]);
+  const errorMessage3 = screen.getByText(props.messages[2]);
+
+  expect(errorMessage1).toBeInTheDocument();
+  expect(errorMessage2).toBeInTheDocument();
+  expect(errorMessage3).toBeInTheDocument();
+});
+
+test("Given a className prop, When the component renders, Then className should be present", () => {
+  const props = {
+    className: "classname-test",
+    messages: ["here is an error"],
+  };
+
+  render(<ErrorMessage {...props} />);
+
+  const errorMessage = screen.getByText(props.messages[0]);
+
+  expect(errorMessage).toHaveClass(props.className);
+});

--- a/client/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/client/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,24 @@
+import classnames from "classnames";
+
+interface ErrorMessageProps {
+  className?: string;
+  messages: string[];
+}
+
+const ErrorMessage: React.FC<ErrorMessageProps> = ({ className, messages }) => {
+  return (
+    <>
+      {messages.map((message, i) => (
+        <span
+          key={i}
+          className={classnames("error", className)}
+          aria-live="polite"
+        >
+          {message}
+        </span>
+      ))}
+    </>
+  );
+};
+
+export default ErrorMessage;

--- a/client/src/components/PlayerScore/PlayerScore.test.tsx
+++ b/client/src/components/PlayerScore/PlayerScore.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import PlayerScore from "./PlayerScore";
+
+test("Given the required props, When the component renders, Then the first element should have the correct className.", () => {
+  const props = {
+    playerName: "",
+    playerId: "",
+    updateName: () => {},
+    playerScore: 0,
+    currentRound: 1,
+    totalRounds: 5,
+    roundWinners: [],
+  };
+  const { container } = render(<PlayerScore {...props} />);
+
+  expect(container.firstChild).toHaveClass("player-score");
+});
+
+test("Given the required props, When the component renders, Then the playerScore should be present", () => {
+  const props = {
+    playerName: "",
+    playerId: "",
+    updateName: () => {},
+    playerScore: 0,
+    currentRound: 1,
+    totalRounds: 5,
+    roundWinners: [],
+  };
+  render(<PlayerScore {...props} />);
+
+  const someNumberText = screen.getByText(props.playerScore);
+
+  expect(someNumberText).toBeInTheDocument();
+  expect(someNumberText).toHaveClass("player-score__total");
+});

--- a/client/src/components/PlayerScore/PlayerScore.tsx
+++ b/client/src/components/PlayerScore/PlayerScore.tsx
@@ -28,17 +28,20 @@ const PlayerScore: React.FC<PlayerScoreProps> = ({
   allRounds.splice(0, roundScores.length, ...roundScores);
 
   return (
-    <>
-      <TextInput
-        value={playerName}
-        label=""
-        name={playerId}
-        id={playerId}
-        onChange={updateName}
-      />
-      <span>{playerScore}</span>
+    <div className="player-score">
+      <div>
+        <TextInput
+          className="player-score__name"
+          value={playerName}
+          label=""
+          name={playerId}
+          id={playerId}
+          onChange={updateName}
+        />
+        <span className="player-score__total">{playerScore}</span>
+      </div>
       <RoundTracker rounds={allRounds} currentRound={currentRound} />
-    </>
+    </div>
   );
 };
 

--- a/client/src/components/PlayerScore/PlayerScore.tsx
+++ b/client/src/components/PlayerScore/PlayerScore.tsx
@@ -1,0 +1,45 @@
+import RoundTracker from "../RoundTracker/RoundTracker";
+import TextInput from "../TextInput/TextInput";
+
+interface PlayerScoreProps {
+  playerName: string;
+  playerId: string;
+  updateName: (id: string, value: string) => void;
+  playerScore: number;
+  currentRound: number;
+  totalRounds: number;
+  roundWinners: string[];
+}
+
+const PlayerScore: React.FC<PlayerScoreProps> = ({
+  playerName,
+  playerId,
+  updateName,
+  playerScore,
+  currentRound,
+  totalRounds,
+  roundWinners,
+}) => {
+  const roundScores = roundWinners.map((round) =>
+    round === playerId ? "won" : "lost"
+  );
+  const allRounds = Array(totalRounds).fill("unresolved");
+
+  allRounds.splice(0, roundScores.length, ...roundScores);
+
+  return (
+    <>
+      <TextInput
+        value={playerName}
+        label=""
+        name={playerId}
+        id={playerId}
+        onChange={updateName}
+      />
+      <span>{playerScore}</span>
+      <RoundTracker rounds={allRounds} currentRound={currentRound} />
+    </>
+  );
+};
+
+export default PlayerScore;

--- a/client/src/components/RoundTracker/RoundTracker.test.tsx
+++ b/client/src/components/RoundTracker/RoundTracker.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import RoundTracker from "./RoundTracker";
+
+test("Given the required props, When the component renders, Then a list should be present", () => {
+  const props = {
+    currentRound: 1,
+    rounds: [],
+  };
+  render(<RoundTracker {...props} />);
+
+  const someListItem = screen.getByRole("list");
+
+  expect(someListItem).toHaveClass("player-score__round-list");
+  expect(someListItem).toBeInTheDocument();
+});
+
+test("Given the required props, When the component renders, Then a the first element should have the correct className", () => {
+  const props = {
+    currentRound: 1,
+    rounds: [],
+  };
+  const { container } = render(<RoundTracker {...props} />);
+
+  expect(container.firstChild).toHaveClass("player-score__round-tracker");
+});
+
+test("Given the required props, When the component renders, Then the text should be present", () => {
+  const props = {
+    currentRound: 1,
+    rounds: [],
+  };
+  render(<RoundTracker {...props} />);
+
+  const someText = screen.getByText("Rounds:");
+
+  expect(someText).toHaveClass("player-score__round-tracker");
+  expect(someText).toBeInTheDocument();
+});

--- a/client/src/components/RoundTracker/RoundTracker.tsx
+++ b/client/src/components/RoundTracker/RoundTracker.tsx
@@ -12,14 +12,16 @@ const RoundTracker: React.FC<RoundTrackerProps> = ({
 }) => {
   return (
     <>
-      <span>Rounds:{currentRound}</span>
-      <div>
-        {rounds.map((round, i) => (
-          <RoundTrackerPip
-            isCurrentRound={i + 1 === currentRound}
-            roundState={round}
-          />
-        ))}
+      <div className="player-score__round-tracker">
+        Rounds:
+        <ol className="player-score__round-list">
+          {rounds.map((round, i) => (
+            <RoundTrackerPip
+              isCurrentRound={i + 1 === currentRound}
+              roundState={round}
+            />
+          ))}
+        </ol>
       </div>
     </>
   );

--- a/client/src/components/RoundTracker/RoundTracker.tsx
+++ b/client/src/components/RoundTracker/RoundTracker.tsx
@@ -17,6 +17,7 @@ const RoundTracker: React.FC<RoundTrackerProps> = ({
         <ol className="player-score__round-list">
           {rounds.map((round, i) => (
             <RoundTrackerPip
+              key={i}
               isCurrentRound={i + 1 === currentRound}
               roundState={round}
             />

--- a/client/src/components/RoundTracker/RoundTracker.tsx
+++ b/client/src/components/RoundTracker/RoundTracker.tsx
@@ -1,0 +1,27 @@
+import { RoundTrackerPip, RoundState } from "./RoundTrackerPip/RoundTrackerPip";
+
+interface RoundTrackerProps {
+  currentRound: number;
+  rounds: RoundState[];
+}
+
+const RoundTracker: React.FC<RoundTrackerProps> = ({
+  currentRound,
+  rounds,
+}) => {
+  return (
+    <>
+      <span>Rounds:{currentRound}</span>
+      <div>
+        {rounds.map((round, i) => (
+          <RoundTrackerPip
+            isCurrentRound={i + 1 === currentRound}
+            roundState={round}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default RoundTracker;

--- a/client/src/components/RoundTracker/RoundTracker.tsx
+++ b/client/src/components/RoundTracker/RoundTracker.tsx
@@ -1,4 +1,5 @@
-import { RoundTrackerPip, RoundState } from "./RoundTrackerPip/RoundTrackerPip";
+import RoundTrackerPip from "./RoundTrackerPip/RoundTrackerPip";
+import { RoundState } from "./RoundTracker.types";
 
 interface RoundTrackerProps {
   currentRound: number;

--- a/client/src/components/RoundTracker/RoundTracker.types.ts
+++ b/client/src/components/RoundTracker/RoundTracker.types.ts
@@ -1,0 +1,2 @@
+export const ROUND_STATES = ["won", "lost", "unresolved"] as const;
+export type RoundState = (typeof ROUND_STATES)[number];

--- a/client/src/components/RoundTracker/RoundTrackerPip/RoundTrackerPip.test.tsx
+++ b/client/src/components/RoundTracker/RoundTrackerPip/RoundTrackerPip.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import RoundTrackerPip from "./RoundTrackerPip";
+import { RoundState } from "../RoundTracker.types";
+
+test("Given the required props, When the component renders, Then a listitem should be present", () => {
+  const props = {
+    isCurrentRound: true,
+    roundState: "won" as RoundState,
+  };
+  render(<RoundTrackerPip {...props} />);
+
+  const someListItem = screen.getByRole("listitem");
+
+  expect(someListItem).toHaveClass("player-score__round");
+  expect(someListItem).toBeInTheDocument();
+});
+
+test("Given a winning roundState prop, When the component renders, Then a listitem with the correct className should be present", () => {
+  const props = {
+    isCurrentRound: true,
+    roundState: "won" as RoundState,
+  };
+  render(<RoundTrackerPip {...props} />);
+
+  const someListItem = screen.getByRole("listitem");
+
+  expect(someListItem).toHaveClass(`player-score__round--${props.roundState}`);
+});
+
+test("Given a losing roundState prop, When the component renders, Then a listitem with the correct className should be present", () => {
+  const props = {
+    isCurrentRound: true,
+    roundState: "lost" as RoundState,
+  };
+  render(<RoundTrackerPip {...props} />);
+
+  const someListItem = screen.getByRole("listitem");
+
+  expect(someListItem).toHaveClass(`player-score__round--${props.roundState}`);
+});
+
+test("Given an unresolved roundState prop, When the component renders, Then a listitem with the correct className should be present", () => {
+  const props = {
+    isCurrentRound: true,
+    roundState: "unresolved" as RoundState,
+  };
+  render(<RoundTrackerPip {...props} />);
+
+  const someListItem = screen.getByRole("listitem");
+
+  expect(someListItem).toHaveClass(`player-score__round--${props.roundState}`);
+});
+
+test("Given a true isCurrentRound prop, When the component renders, Then a listitem with the correct className should be present", () => {
+  const props = {
+    isCurrentRound: true,
+    roundState: "unresolved" as RoundState,
+  };
+  render(<RoundTrackerPip {...props} />);
+
+  const someListItem = screen.getByRole("listitem");
+
+  expect(someListItem).toHaveClass(`player-score__round--current`);
+});
+
+test("Given a false isCurrentRound prop, When the component renders, Then a listitem with the correct className should be present", () => {
+  const props = {
+    isCurrentRound: false,
+    roundState: "unresolved" as RoundState,
+  };
+  render(<RoundTrackerPip {...props} />);
+
+  const someListItem = screen.getByRole("listitem");
+
+  expect(someListItem).not.toHaveClass(`player-score__round--current`);
+});

--- a/client/src/components/RoundTracker/RoundTrackerPip/RoundTrackerPip.tsx
+++ b/client/src/components/RoundTracker/RoundTrackerPip/RoundTrackerPip.tsx
@@ -1,0 +1,21 @@
+import classnames from "classnames";
+
+export const ROUND_STATES = ["won", "lost", "unresolved"] as const;
+export type RoundState = (typeof ROUND_STATES)[number];
+
+interface RoundTrackerPipProps {
+  isCurrentRound: boolean;
+  roundState: RoundState;
+}
+
+export const RoundTrackerPip: React.FC<RoundTrackerPipProps> = ({
+  isCurrentRound,
+  roundState,
+}) => {
+  const classNames = classnames({
+    "current-round": isCurrentRound,
+    [`round-${roundState}`]: roundState,
+  });
+
+  return <span className={classNames}></span>;
+};

--- a/client/src/components/RoundTracker/RoundTrackerPip/RoundTrackerPip.tsx
+++ b/client/src/components/RoundTracker/RoundTrackerPip/RoundTrackerPip.tsx
@@ -1,14 +1,12 @@
 import classnames from "classnames";
-
-export const ROUND_STATES = ["won", "lost", "unresolved"] as const;
-export type RoundState = (typeof ROUND_STATES)[number];
+import { RoundState } from "../RoundTracker.types";
 
 interface RoundTrackerPipProps {
   isCurrentRound: boolean;
   roundState: RoundState;
 }
 
-export const RoundTrackerPip: React.FC<RoundTrackerPipProps> = ({
+const RoundTrackerPip: React.FC<RoundTrackerPipProps> = ({
   isCurrentRound,
   roundState,
 }) => {
@@ -19,3 +17,5 @@ export const RoundTrackerPip: React.FC<RoundTrackerPipProps> = ({
 
   return <span className={classNames}></span>;
 };
+
+export default RoundTrackerPip;

--- a/client/src/components/RoundTracker/RoundTrackerPip/RoundTrackerPip.tsx
+++ b/client/src/components/RoundTracker/RoundTrackerPip/RoundTrackerPip.tsx
@@ -10,12 +10,13 @@ const RoundTrackerPip: React.FC<RoundTrackerPipProps> = ({
   isCurrentRound,
   roundState,
 }) => {
-  const classNames = classnames({
-    "current-round": isCurrentRound,
-    [`round-${roundState}`]: roundState,
+  const baseClassName = "player-score__round";
+  const classNames = classnames(baseClassName, {
+    [`${baseClassName}--current`]: isCurrentRound,
+    [`${baseClassName}--${roundState}`]: roundState,
   });
 
-  return <span className={classNames}></span>;
+  return <li className={classNames}></li>;
 };
 
 export default RoundTrackerPip;

--- a/client/src/components/TextInput/TextInput.test.tsx
+++ b/client/src/components/TextInput/TextInput.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import TextInput from "./TextInput";
+import userEvent from "@testing-library/user-event";
+
+test("Given the required props, When the component is rendered, Then there should be an input element", () => {
+  const props = {
+    label: "",
+    name: "",
+    id: "",
+    value: "",
+    onChange: () => {},
+  };
+
+  render(<TextInput {...props} />);
+
+  const someTextInput = screen.getByRole("textbox");
+
+  expect(someTextInput).toBeInTheDocument();
+  expect(someTextInput.tagName).toBe("INPUT");
+  expect(someTextInput.getAttribute("type")).toBe("text");
+});
+
+test("Given the required props, When the component is rendered, Then there should be a label element", () => {
+  const props = {
+    label: "",
+    name: "",
+    id: "",
+    value: "",
+    onChange: () => {},
+  };
+
+  const { container } = render(<TextInput {...props} />);
+
+  expect(container.firstChild?.nodeName === "LABEL").toBe(true);
+});
+
+test("Given the required props, When the component is rendered, Then the input element should be within a label element", () => {
+  const props = {
+    label: "",
+    name: "",
+    id: "",
+    value: "",
+    onChange: () => {},
+  };
+
+  const { container } = render(<TextInput {...props} />);
+
+  const label = container.firstChild;
+  const someTextInput = screen.getByRole("textbox");
+  const containsInput = label?.contains(someTextInput);
+
+  expect(containsInput).toBeTruthy();
+});
+
+test("Given the required props, When the component is rendered, Then the label text should be present", () => {
+  const props = {
+    label: "Some label",
+    name: "",
+    id: "",
+    value: "",
+    onChange: () => {},
+  };
+
+  render(<TextInput {...props} />);
+
+  const someLabelText = screen.getByLabelText(`${props.label}:`);
+  expect(someLabelText).toBeInTheDocument();
+});
+
+test("Given the required props, When the component is rendered, Then the input value should be present", () => {
+  const props = {
+    label: "",
+    name: "",
+    id: "",
+    value: "test",
+    onChange: () => {},
+  };
+
+  render(<TextInput {...props} />);
+
+  const someTextInput = screen.getByRole("textbox");
+  expect(someTextInput).toHaveValue(props.value);
+});
+
+test("Given the component is rendered, When the user types in the input, Then the onChange function is called", async () => {
+  const user = userEvent.setup();
+
+  const mockOnChange = vi.fn();
+
+  const props = {
+    label: "",
+    name: "",
+    id: "",
+    value: "",
+    onChange: mockOnChange,
+  };
+
+  render(<TextInput {...props} />);
+
+  const someTextInput = screen.getByRole("textbox");
+
+  await user.type(someTextInput, "test");
+
+  expect(mockOnChange).toBeCalled();
+  expect(mockOnChange).toBeCalledTimes(4);
+});
+
+test("Given a className prop, When the component renders, Then className should be present", () => {
+  const props = {
+    className: "test-classname",
+    label: "",
+    name: "",
+    id: "",
+    value: "test",
+    onChange: () => {},
+  };
+
+  const { container } = render(<TextInput {...props} />);
+
+  expect(container.firstChild).toHaveClass(props.className);
+});

--- a/client/src/components/TextInput/TextInput.tsx
+++ b/client/src/components/TextInput/TextInput.tsx
@@ -1,0 +1,47 @@
+import classnames from "classnames";
+
+import ErrorMessage from "../ErrorMessage/ErrorMessage";
+
+interface TextInputProps {
+  className?: string;
+  label: string;
+  name: string;
+  id: string;
+  value: string;
+  onChange: (id: string, value: string) => void;
+  validate?: (value: string) => string[];
+}
+
+const TextInput: React.FC<TextInputProps> = (props) => {
+  const { className, label, name, id, value, onChange, validate } = props;
+
+  const errorMessages = validate && validate(value);
+
+  return (
+    <label
+      className={classnames(
+        "text-input__label",
+        errorMessages && "text-input__label--error",
+        className
+      )}
+    >
+      {label && `${label}: `}
+      <input
+        className="text-input"
+        type="text"
+        name={name}
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.id, e.target.value)}
+      />
+      {errorMessages && errorMessages.length > 0 && (
+        <ErrorMessage
+          className={"text-input__error"}
+          messages={errorMessages}
+        />
+      )}
+    </label>
+  );
+};
+
+export default TextInput;

--- a/client/src/constants/constants.ts
+++ b/client/src/constants/constants.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_STARTING_PLAYERS = [
+  { name: "Player 1", id: "player1", score: 0 },
+  { name: "Player 2", id: "player2", score: 0 },
+];
+export const DEFAULT_ROUNDS = 5;


### PR DESCRIPTION
I've added components for PlayerScore, RoundTracker, and RoundTrackerPip, as well as two utility components TextInput and ErrorMessage. All components have tests, but no styling has been applied yet. I also added some default constants for DEFAULT_ROUNDS and DEFAULT_STARTING_PLAYERS.

PlayerScore doesn't have a function for updateName, as we will likely want to hold this in a parent state and pass the function down to the component to set that state.