### PR TITLE
fix: Restore PlayerScore and DEFAULT_ROUNDS imports to App

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,6 @@
 import "./App.scss";
+import PlayerScore from "./components/PlayerScore/PlayerScore";
+import { DEFAULT_ROUNDS } from "./constants/constants";
 
 function App() {
   return (


### PR DESCRIPTION
Accidentally removed the PlayerScore and DEFAULT_ROUNDS imports from App.tsx when resolving a merge conflict. Have restored them in this PR.