### PR TITLE
refactor: remove currentRound and derive from roundWinner.length

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,7 +19,6 @@ function App() {
         playerId={player1.id}
         updateName={() => {}}
         playerScore={player1.score}
-        currentRound={game.currentRound}
         totalRounds={game.totalRounds}
         roundWinners={[]}
       />
@@ -28,7 +27,6 @@ function App() {
         playerId={player2.id}
         updateName={() => {}}
         playerScore={player2.score}
-        currentRound={game.currentRound}
         totalRounds={game.totalRounds}
         roundWinners={[]}
       />

--- a/client/src/components/PlayerScore/PlayerScore.tsx
+++ b/client/src/components/PlayerScore/PlayerScore.tsx
@@ -6,7 +6,6 @@ interface PlayerScoreProps {
   playerId: string;
   updateName: (id: string, value: string) => void;
   playerScore: number;
-  currentRound: number;
   totalRounds: number;
   roundWinners: string[];
 }
@@ -16,7 +15,6 @@ const PlayerScore: React.FC<PlayerScoreProps> = ({
   playerId,
   updateName,
   playerScore,
-  currentRound,
   totalRounds,
   roundWinners,
 }) => {
@@ -40,7 +38,7 @@ const PlayerScore: React.FC<PlayerScoreProps> = ({
         />
         <span className="player-score__total">{playerScore}</span>
       </div>
-      <RoundTracker rounds={allRounds} currentRound={currentRound} />
+      <RoundTracker rounds={allRounds} currentRound={roundWinners.length + 1} />
     </div>
   );
 };

--- a/client/src/service/game.test.tsx
+++ b/client/src/service/game.test.tsx
@@ -6,7 +6,6 @@ describe("Game", () => {
 
     expect(game.totalRounds).toBe(4);
     expect(game.roundWinners.length).toBe(0);
-    expect(game.currentRound).toBe(0);
 
     expect(game.players.length).toBe(3);
     const player1 = game.players[0];

--- a/client/src/service/game.ts
+++ b/client/src/service/game.ts
@@ -27,7 +27,6 @@ export function initialiseGame(
     players: players,
     totalRounds: numberOfRoundsToPlay,
     roundWinners: [],
-    currentRound: 0,
   };
   return game;
 }

--- a/client/src/types/game/game.types.tsx
+++ b/client/src/types/game/game.types.tsx
@@ -3,6 +3,5 @@ import { Player } from "../player/player.types";
 export type Game = {
   players: Player[];
   totalRounds: number;
-  currentRound: number;
   roundWinners: Player[];
 };


### PR DESCRIPTION
An example of how we can remove currentRound and so remove it from useRef. 
