### PR TITLE
Add starter styles

### DIFF
--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -1,3 +1,7 @@
+@import "./styles/reset";
+@import "./styles/helpers";
+@import "./styles/variables";
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./index.scss";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-)
+  </React.StrictMode>
+);

--- a/client/src/styles/_helpers.scss
+++ b/client/src/styles/_helpers.scss
@@ -1,0 +1,11 @@
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}

--- a/client/src/styles/_reset.scss
+++ b/client/src/styles/_reset.scss
@@ -1,0 +1,54 @@
+/*
+  Josh's Custom CSS Reset
+  https://www.joshwcomeau.com/css/custom-css-reset/
+*/
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+* {
+  margin: 0;
+}
+body {
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+textarea {
+  resize: none;
+}
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}
+
+[type="search"] {
+  outline-offset: -2px;
+  -webkit-appearance: textfield;
+}
+
+#root,
+#__next {
+  isolation: isolate;
+}
+
+/*-------------------------------------*/

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -1,0 +1,10 @@
+$red: #e3350d;
+$orange: #ee6b2f;
+$yellow: #e6bc2f;
+$green: #4dad5b;
+$blue: #1847d7;
+$purple: #855ac9;
+$grey: #919191;
+$light-grey: #f5f5f5;
+$white: #fff;
+$black: #000;


### PR DESCRIPTION
A quick PR mainly to add reset styles and the visually-hidden class styles. I added the other partials here just so they were also set up, then added some colours variables to _variables.scss too.

## What's in the PR

### styles folder

_reset.scss
- adds _reset.scss partial with Josh Comeau's css reset styles

_helpers.scss
- adds _helpers.scss with visually-hidden helper class to hide text from non-screen reader users

_variables.scss
- adds _variables.scss with initial colour palette variables taken from here https://www.onlinepalette.com/pokemon/ (Website section)

_functions.scss
- adds _functions.scss to store sass functions

### src folder

index.css 
- changes file type to index.scss and imports _reset.scss, _helpers.scss and _variables.scss partials at the top of the file

main.tsx
- updates the index.css import to index.scss